### PR TITLE
fix: missing linebreak

### DIFF
--- a/sample-docs/long-page.rst
+++ b/sample-docs/long-page.rst
@@ -55,6 +55,7 @@ Pellentesque nec est in odio ultrices elementum. Vestibulum et hendrerit sapien,
 Suspendisse potenti. Curabitur tristique sit amet lectus non viverra. Phasellus rutrum dapibus turpis sed imperdiet.
 Mauris maximus viverra ante. Donec eu egestas mauris. Morbi vulputate tincidunt euismod. Integer vel porttitor neque.
 Donec at lacus suscipit, lacinia lectus vel, sagittis lectus.
+
 Document Section
 ================
 


### PR DESCRIPTION
Add an empty line ahead of a heading in `long-page.rst` that prevented a heading to be rendered.